### PR TITLE
Fix Display:flex on firefox has a bug with width and height and 100%

### DIFF
--- a/designer/src/main/webapp/archetype-editor.css
+++ b/designer/src/main/webapp/archetype-editor.css
@@ -87,6 +87,8 @@ label {
   pading-left: 10px;
   flex: 1;
   -webkit-flex: 1;
+    min-height: 1px;
+    min-width: 1px;
 }
 
 .navbar-right {


### PR DESCRIPTION
Don't know if you are accepting PR but i found a bug in Firefox and MS Edge.

Found some reports on SO that these browsers misbehaves when you use display:flex and width: 100% or height :100% or if you use overflow.

The current fix seems to be to set a min-height/min-width to some small value (1px) in this case the offending element are the ones with the tab-pane class.
